### PR TITLE
sync roll for all players

### DIFF
--- a/src/tension-pool.js
+++ b/src/tension-pool.js
@@ -263,7 +263,7 @@ async function adddie(message=undefined,count=1){
         let dicesize = game.settings.get("tension-pool",'dicesize');
         let Ro = new Roll(count+dicesize);
         await Ro.evaluate({async:true})
-        game.dice3d.showForRoll(Ro, game.user, false, null);
+        game.dice3d.showForRoll(Ro, game.user, true, null);
     }
 
     game.settings.set("tension-pool",'diceinpool',diceinpool);


### PR DESCRIPTION
Changed the roll when "dropdie" is on and a die is added, to sync roll between all players, showing the roll to players.

Fixes #32 